### PR TITLE
Upgrading illuminate/support and illuminate/routing to v9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "illuminate/routing": "^9.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "~8.0",
+    "phpunit/phpunit": "~9.5",
     "mockery/mockery": "0.9.*"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,11 @@
   "require": {
     "php": ">=7.1.3",
     "guzzlehttp/guzzle": "~7.0|~6.0|~5.0|~4.0",
-    "illuminate/support": "~8.0|~7.0|~6.0|^5.5",
-    "illuminate/routing": "~8.0|~7.0|~6.0|^5.5"
+    "illuminate/support": "^9.0",
+    "illuminate/routing": "^9.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "~7.0",
+    "phpunit/phpunit": "~8.0",
     "mockery/mockery": "0.9.*"
   },
   "autoload": {


### PR DESCRIPTION
- `illuminate/support` -> `^9.0`
- `illuminate/routing` -> `^9.0`
- `phpunit/phpunit` -> `~9.5`